### PR TITLE
Add test project; allow any object as SendRequest.Data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,6 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# SendWithUs.Client test data
+SendWithUs.Client.Tests/EndToEnd/Data/

--- a/.nuget/NuGet.Config
+++ b/.nuget/NuGet.Config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <solution>
+        <add key="disableSourceControlIntegration" value="true" />
+    </solution>
+</configuration>

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ var client = new SendWithUsClient("my-api-key");
 var response = await client.SendAsync(request);
 ```
 
-#### More Realistic Example
+#### A More Realistic Example
 
 The data passed to SendRequest can be any CLR object, as long as it serializes as a JSON object.
 
@@ -58,9 +58,9 @@ var response = await client.SendAsync(request);
 
 #### Typed Request Data
 
-The type of the `Data` property on SendRequest is plain old object. If you want a strongly-typed Data property, use
-SendRequest<TData> in lieu of SendRequest. This is merely a developer convenience. SendRequest<TData> shadows the 
-Data property of SendRequest and casts it to the specified type.
+The type of the `Data` property on `SendRequest` is plain old object. If you want a strongly-typed `Data` property, use
+`SendRequest<TData>` in lieu of `SendRequest`. This is merely a developer convenience. `SendRequest<TData>` shadows the 
+`Data` property of `SendRequest` and casts it to the specified type.
 
 ### Batching
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ var client = new SendWithUsClient("my-api-key");
 var response = await client.SendAsync(request);
 ```
 
+#### Typed Request Data
+
+The type of the `Data` property on SendRequest is plain old object. If you want a strongly-typed Data property, use
+SendRequest<TData> in lieu of SendRequest. This is merely a developer convenience. SendRequest<TData> shadows the 
+Data property of SendRequest and casts it to the specified type.
+
 ### Batching
 
 To make a batch request, pass a collection of request objects to `SendWithUsClient.BatchAsync`. (Note that the only type

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ have a `TemplateId` and a `RecipientAddress`. All other properties are optional.
 #### Minimal Example
 
 ```csharp
+using SendWithUs.Client;
+
 var request = new SendRequest("template123", "foo@example.com");
 var client = new SendWithUsClient("my-api-key");
 var response = await client.SendAsync(request);
@@ -34,12 +36,21 @@ var response = await client.SendAsync(request);
 
 #### More Realistic Example
 
+The data passed to SendRequest can be any CLR object, as long as it serializes as a JSON object.
+
 ```csharp
-var data = new Dictionary<string, string> { {"name", "Rosco P. Coltrane"}, {"title", "Sheriff"} };
-var request = new SendRequest("disciplinary-form", "rosco@hazzard.example.com", data)
+using SendWithUs.Client;
+
+var sheriff = new Person { ... };
+var wristslap = new Punishment { ... };
+var data = new Dictionary<string, object> { { "who", sheriff }, { "what", wristslap } };
+var request = new SendRequest
 {
+    TemplateId = "disciplinary-form",
     SenderName = "Boss Hogg",
-    SenderAddress = "j.d.hogg@hazzard.example.com"
+    SenderAddress = "j.d.hogg@hazzard.example.com",
+    RecipientAddress = "rosco@hazzard.example.com",
+    Data = data
 };
 var client = new SendWithUsClient("my-api-key");
 var response = await client.SendAsync(request);
@@ -53,6 +64,8 @@ of request object currently supported is `SendRequest`.)
 #### Example
 
 ```csharp
+using SendWithUs.Client;
+
 var request1 = new SendRequest("template123", "foo@example.com");
 var request2 = new SendRequest("template567", "bar@example.com");
 var client = new SendWithUsClient("my-api-key");

--- a/SendWithUs.Client.Tests/Component/BatchRequestWrapperConverterTests.cs
+++ b/SendWithUs.Client.Tests/Component/BatchRequestWrapperConverterTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Component
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class BatchRequestWrapperConverterTests : ComponentTestsBase
+    {
+        [TestMethod]
+        public void WriteJson_ValidBatchRequestWrapper_Succeeds()
+        {
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var request = new SendRequest(templateId, recipientAddress);
+            var wrapper = new BatchRequestWrapper(request);
+            var writer = JsonObjectWriter.Create();
+            var serializer = JsonSerializer.Create();
+            var converter = new BatchRequestWrapperConverter();
+
+            converter.WriteJson(writer, wrapper, serializer);
+            var jsonObject = writer.Get<JObject>();
+
+            Assert.IsNotNull(jsonObject);
+            var pathProperty = jsonObject.Property("path");
+            Assert.IsNotNull(pathProperty);
+            Assert.IsTrue(pathProperty.HasValues);
+            Assert.AreEqual(request.GetUriPath(), (string)pathProperty.Value);
+            var methodProperty = jsonObject.Property("method");
+            Assert.IsNotNull(methodProperty);
+            Assert.IsTrue(methodProperty.HasValues);
+            Assert.AreEqual(request.GetHttpMethod(), (string)methodProperty.Value);
+            var bodyProperty = jsonObject.Property("body");
+            Assert.IsNotNull(bodyProperty);
+            Assert.IsInstanceOfType(bodyProperty.Value, typeof(JObject));
+            this.ValidateSendRequest(bodyProperty.Value as JObject, templateId, recipientAddress, false);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Component/BatchRequestWrapperConverterTests.cs
+++ b/SendWithUs.Client.Tests/Component/BatchRequestWrapperConverterTests.cs
@@ -35,12 +35,12 @@ namespace SendWithUs.Client.Tests.Component
             var recipientAddress = TestHelper.GetUniqueId();
             var request = new SendRequest(templateId, recipientAddress);
             var wrapper = new BatchRequestWrapper(request);
-            var writer = JsonObjectWriter.Create();
+            var writer = BufferedJsonStringWriter.Create();
             var serializer = JsonSerializer.Create();
             var converter = new BatchRequestWrapperConverter();
 
             converter.WriteJson(writer, wrapper, serializer);
-            var jsonObject = writer.Get<JObject>();
+            var jsonObject = writer.GetBufferAs<JObject>();
 
             Assert.IsNotNull(jsonObject);
             var pathProperty = jsonObject.Property("path");

--- a/SendWithUs.Client.Tests/Component/BufferedJsonStringWriter.cs
+++ b/SendWithUs.Client.Tests/Component/BufferedJsonStringWriter.cs
@@ -25,23 +25,23 @@ namespace SendWithUs.Client.Tests.Component
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
-    public class JsonObjectWriter : JsonTextWriter
+    public class BufferedJsonStringWriter : JsonTextWriter
     {
         protected StringWriter Buffer { get; set; }
 
-        protected JsonObjectWriter(StringWriter buffer) : base(buffer)
+        protected BufferedJsonStringWriter(StringWriter buffer) : base(buffer)
         { }
 
-        public static JsonObjectWriter Create()
+        public static BufferedJsonStringWriter Create()
         {
             var buffer = new StringWriter();
-            var instance = new JsonObjectWriter(buffer);
+            var instance = new BufferedJsonStringWriter(buffer);
 
             instance.Buffer = buffer;
             return instance;
         }
 
-        public T Get<T>() where T : JToken
+        public T GetBufferAs<T>() where T : JToken
         {
             return JToken.Parse(this.Buffer.ToString()) as T;
         }

--- a/SendWithUs.Client.Tests/Component/ComponentTestsBase.cs
+++ b/SendWithUs.Client.Tests/Component/ComponentTestsBase.cs
@@ -1,0 +1,60 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Component
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
+
+    public abstract class ComponentTestsBase
+    {
+        protected void ValidateSendRequest(JObject jsonObject, string expectedEmailId, string expectedRecipientAddress, bool allowOtherProperties)
+        {
+            var emailIdFound = false;
+            var recipientAddressFound = false;
+
+            foreach (var pair in jsonObject)
+            {
+                switch (pair.Key)
+                {
+                    case "email_id":
+                        Assert.AreEqual(expectedEmailId, pair.Value);
+                        emailIdFound = true;
+                        break;
+
+                    case "recipient":
+                        Assert.AreEqual(expectedRecipientAddress, pair.Value["address"].Value<string>());
+                        recipientAddressFound = true;
+                        break;
+
+                    default:
+                        if (!allowOtherProperties)
+                        {
+                            Assert.Fail("Unexpected object property '{0}'", pair.Key);
+                        }
+                        break;
+                }
+            }
+
+            Assert.IsTrue(emailIdFound);
+            Assert.IsTrue(recipientAddressFound);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Component/JsonObjectWriter.cs
+++ b/SendWithUs.Client.Tests/Component/JsonObjectWriter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2014 Mimeo, Inc.
+﻿// Copyright © 2015 Mimeo, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,33 +18,32 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-namespace SendWithUs.Client
+namespace SendWithUs.Client.Tests.Component
 {
+    using System;
+    using System.IO;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
-    /// <summary>
-    /// Wraps an IRequest object for use in a batch request.
-    /// </summary>
-    /// <remarks>This class MUST NOT implement IRequest.</remarks>
-    [JsonConverter(typeof(BatchRequestWrapperConverter))]
-    public class BatchRequestWrapper
+    public class JsonObjectWriter : JsonTextWriter
     {
-        public virtual string Method
+        protected StringWriter Buffer { get; set; }
+
+        protected JsonObjectWriter(StringWriter buffer) : base(buffer)
+        { }
+
+        public static JsonObjectWriter Create()
         {
-            get { return this.InnerRequest.GetHttpMethod(); }
+            var buffer = new StringWriter();
+            var instance = new JsonObjectWriter(buffer);
+
+            instance.Buffer = buffer;
+            return instance;
         }
 
-        public virtual string Path
+        public T Get<T>() where T : JToken
         {
-            get { return this.InnerRequest.GetUriPath(); }
-        }
-
-        public virtual IRequest InnerRequest { get; protected set; }
-
-        public BatchRequestWrapper(IRequest innerRequest)
-        {
-            EnsureArgument.NotNull(innerRequest, "innerRequest");
-            this.InnerRequest = innerRequest;
+            return JToken.Parse(this.Buffer.ToString()) as T;
         }
     }
 }

--- a/SendWithUs.Client.Tests/Component/SendRequestConverterTests.cs
+++ b/SendWithUs.Client.Tests/Component/SendRequestConverterTests.cs
@@ -1,0 +1,79 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Component
+{
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using SendWithUs.Client;
+
+    [TestClass]
+    public class SendRequestConverterTests : ComponentTestsBase
+    {
+        #region Helpers
+
+        #endregion
+
+        #region Test methods
+
+        [TestMethod]
+        public void WriteJson_MinimalSendRequest_Succeeds()
+        {
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var request = new SendRequest(templateId, recipientAddress);
+            var writer = JsonObjectWriter.Create();
+            var serializer = JsonSerializer.Create();
+            var converter = new SendRequestConverter();
+
+            converter.WriteJson(writer, request, serializer);
+            var jsonObject = writer.Get<JObject>();
+
+            Assert.IsNotNull(jsonObject);
+            this.ValidateSendRequest(jsonObject, templateId, recipientAddress, false);
+        }
+
+        [TestMethod]
+        public void WriteJson_WithData_IncludesAllData()
+        {
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var data = TestHelper.GetRandomData();
+            var request = new SendRequest(templateId, recipientAddress, data);
+            var writer = JsonObjectWriter.Create();
+            var serializer = new JsonSerializer();
+            var converter = new SendRequestConverter();
+
+            converter.WriteJson(writer, request, serializer);
+            var jsonObject = writer.Get<JObject>();
+
+            Assert.IsNotNull(jsonObject);
+            this.ValidateSendRequest(jsonObject, templateId, recipientAddress, true);
+            var jsonData = jsonObject.GetValue("email_data") as JObject;
+            Assert.IsNotNull(jsonData);
+            Assert.AreEqual(data.Count, jsonData.Count);
+        }
+
+        #endregion
+    }
+}

--- a/SendWithUs.Client.Tests/Component/SendRequestConverterTests.cs
+++ b/SendWithUs.Client.Tests/Component/SendRequestConverterTests.cs
@@ -42,12 +42,12 @@ namespace SendWithUs.Client.Tests.Component
             var templateId = TestHelper.GetUniqueId();
             var recipientAddress = TestHelper.GetUniqueId();
             var request = new SendRequest(templateId, recipientAddress);
-            var writer = JsonObjectWriter.Create();
+            var writer = BufferedJsonStringWriter.Create();
             var serializer = JsonSerializer.Create();
             var converter = new SendRequestConverter();
 
             converter.WriteJson(writer, request, serializer);
-            var jsonObject = writer.Get<JObject>();
+            var jsonObject = writer.GetBufferAs<JObject>();
 
             Assert.IsNotNull(jsonObject);
             this.ValidateSendRequest(jsonObject, templateId, recipientAddress, false);
@@ -60,12 +60,12 @@ namespace SendWithUs.Client.Tests.Component
             var recipientAddress = TestHelper.GetUniqueId();
             var data = TestHelper.GetRandomData();
             var request = new SendRequest(templateId, recipientAddress, data);
-            var writer = JsonObjectWriter.Create();
+            var writer = BufferedJsonStringWriter.Create();
             var serializer = new JsonSerializer();
             var converter = new SendRequestConverter();
 
             converter.WriteJson(writer, request, serializer);
-            var jsonObject = writer.Get<JObject>();
+            var jsonObject = writer.GetBufferAs<JObject>();
 
             Assert.IsNotNull(jsonObject);
             this.ValidateSendRequest(jsonObject, templateId, recipientAddress, true);

--- a/SendWithUs.Client.Tests/EndToEnd/SendAsyncTests.cs
+++ b/SendWithUs.Client.Tests/EndToEnd/SendAsyncTests.cs
@@ -1,0 +1,121 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.EndToEnd
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using SendWithUs.Client;
+
+    [TestClass]
+    public class SendAsyncTests
+    {
+        [TestMethod]
+        public void SendAsync_MinimalRequest_Succeeds()
+        {
+            // Arrange
+            var testData = new TestData("EndToEnd/Data/SendRequest.xml");
+            var request = new SendRequest(testData.TemplateId, testData.RecipientAddress);
+            var client = new SendWithUsClient(testData.ApiKey);
+
+            // Act
+            var response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("OK", response.Status, true);
+            Assert.AreEqual(true, response.Success);
+        }
+
+        [TestMethod]
+        public void SendAsync_WithData_Succeeds()
+        {
+            // Arrange
+            var testData = new TestData("EndToEnd/Data/SendRequest.xml");
+            var subject = "SendAsync_WithData " + TestHelper.GetUniqueId();
+            var request = new SendRequest(testData.TemplateId, testData.RecipientAddress, testData.Data.Upsert("subject", subject));
+            var client = new SendWithUsClient(testData.ApiKey);
+
+            // Act 
+            var response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("OK", response.Status, true);
+            Assert.AreEqual(true, response.Success);
+        }
+
+        [TestMethod]
+        public void SendAsync_WithInlineAttachment_Succeeds()
+        {
+            // Arrange
+            var testData = new TestData("EndToEnd/Data/SendRequest.xml");
+            var subject = "SendAsync_WithInlineAttachment " + TestHelper.GetUniqueId();
+            var request = new SendRequest(testData.TemplateId, testData.RecipientAddress, testData.Data.Upsert("subject", subject));
+            var client = new SendWithUsClient(testData.ApiKey);
+
+            request.InlineAttachment = new Attachment
+            {
+                Id = testData.AttachmentFileName,
+                Data = Convert.ToBase64String(File.ReadAllBytes(testData.AttachmentFileName))
+            };
+
+            // Act 
+            var response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("OK", response.Status, true);
+            Assert.AreEqual(true, response.Success);
+        }
+
+
+        [TestMethod]
+        public void SendAsync_WithFileAttachment_Succeeds()
+        {
+            // Arrange
+            var testData = new TestData("EndToEnd/Data/SendRequest.xml");
+            var subject = "SendAsync_WithFileAttachment " + TestHelper.GetUniqueId();
+            var request = new SendRequest(testData.TemplateId, testData.RecipientAddress, testData.Data.Upsert("subject", subject));
+            var client = new SendWithUsClient(testData.ApiKey);
+
+            request.SenderAddress = testData.SenderAddress;
+            request.FileAttachments = new List<IAttachment>
+            {
+                new Attachment
+                {
+                    Id = testData.AttachmentFileName,
+                    Data = Convert.ToBase64String(File.ReadAllBytes(testData.AttachmentFileName))
+                }
+            };
+
+            // Act 
+            var response = client.SendAsync(request).Result;
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual("OK", response.Status, true);
+            Assert.AreEqual(true, response.Success);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/EndToEnd/TestData.cs
+++ b/SendWithUs.Client.Tests/EndToEnd/TestData.cs
@@ -1,0 +1,115 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.EndToEnd
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+
+    public class TestData
+    {
+        public string ApiKey
+        {
+            get { return this.GetString("ApiKey"); }
+        }
+
+        public string TemplateId
+        {
+            get { return this.GetString("TemplateId"); }
+        }
+
+        public string SenderAddress
+        {
+            get { return this.GetString("SenderAddress"); }
+        }
+
+        public string SenderName
+        {
+            get { return this.GetString("SenderName"); }
+        }
+
+        public string SenderReplyTo
+        {
+            get { return this.GetString("SenderReplyTo"); }
+        }
+
+        public string RecipientAddress
+        {
+            get { return this.GetString("RecipientAddress"); }
+        }
+
+        public string RecipientName
+        {
+            get { return this.GetString("RecipientName"); }
+        }
+
+        public IEnumerable<string> CopyTo
+        {
+            get { return null; }
+        }
+
+        public IEnumerable<string> BlindCopyTo
+        {
+            get { return null; }
+        }
+
+        public IDictionary<string, object> Data
+        {
+            get 
+            {
+                var rawData = this.DataSource.Root.Element("Data").Descendants("Item");
+                return rawData.ToDictionary<XElement, string, object>(e => e.Attribute("name").Value, e => e.Attribute("value").Value);
+            }
+        }
+
+        public IEnumerable<string> Tags
+        {
+            get { return null; }
+        }
+
+        public string AttachmentFileName
+        {
+            get { return this.GetString("AttachmentFileName"); }
+        }
+
+        public string ProviderId
+        {
+            get { return this.GetString("ProviderId"); }
+        }
+
+        public string TemplateVersion
+        {
+            get { return this.GetString("TemplateVersion"); }
+        }
+
+        protected XDocument DataSource { get; set; }
+
+        protected string GetString(string name)
+        {
+            return this.DataSource.Root.Element(name).Value;
+        }
+
+        public TestData(string fileName)
+        {
+            this.DataSource = XDocument.Load(fileName);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Extensions.cs
+++ b/SendWithUs.Client.Tests/Extensions.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2014 Mimeo, Inc.
+﻿// Copyright © 2015 Mimeo, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,33 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-namespace SendWithUs.Client
+namespace SendWithUs.Client.Tests
 {
-    using Newtonsoft.Json;
+    using System.Collections.Generic;
 
-    /// <summary>
-    /// Wraps an IRequest object for use in a batch request.
-    /// </summary>
-    /// <remarks>This class MUST NOT implement IRequest.</remarks>
-    [JsonConverter(typeof(BatchRequestWrapperConverter))]
-    public class BatchRequestWrapper
+    public static class Extensions
     {
-        public virtual string Method
+        public static IDictionary<TKey, TValue> Upsert<TKey, TValue>(this IDictionary<TKey, TValue> subject, TKey key, TValue value)
         {
-            get { return this.InnerRequest.GetHttpMethod(); }
-        }
+            if (subject.ContainsKey(key))
+            {
+                subject[key] = value;
+            }
+            else
+            {
+                subject.Add(key, value);
+            }
 
-        public virtual string Path
-        {
-            get { return this.InnerRequest.GetUriPath(); }
-        }
-
-        public virtual IRequest InnerRequest { get; protected set; }
-
-        public BatchRequestWrapper(IRequest innerRequest)
-        {
-            EnsureArgument.NotNull(innerRequest, "innerRequest");
-            this.InnerRequest = innerRequest;
+            return subject;
         }
     }
 }

--- a/SendWithUs.Client.Tests/Extensions.cs
+++ b/SendWithUs.Client.Tests/Extensions.cs
@@ -26,15 +26,7 @@ namespace SendWithUs.Client.Tests
     {
         public static IDictionary<TKey, TValue> Upsert<TKey, TValue>(this IDictionary<TKey, TValue> subject, TKey key, TValue value)
         {
-            if (subject.ContainsKey(key))
-            {
-                subject[key] = value;
-            }
-            else
-            {
-                subject.Add(key, value);
-            }
-
+            subject[key] = value;
             return subject;
         }
     }

--- a/SendWithUs.Client.Tests/Properties/AssemblyInfo.cs
+++ b/SendWithUs.Client.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SendWithUs.Client.Test")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SendWithUs.Client.Test")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("04ed4342-9bd9-48a7-bd55-c35e1776a93c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SendWithUs.Client.Tests/SendWithUs.Client.Tests.csproj
+++ b/SendWithUs.Client.Tests/SendWithUs.Client.Tests.csproj
@@ -94,12 +94,6 @@
     <Compile Include="Unit\SendWithUsClientTests.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="EndToEnd\Data\SendRequest.xml">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="EndToEnd\Data\mimeo-logo-black.png">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
@@ -108,7 +102,9 @@
       <Name>SendWithUs.Client</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Folder Include="EndToEnd\Data\" />
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/SendWithUs.Client.Tests/SendWithUs.Client.Tests.csproj
+++ b/SendWithUs.Client.Tests/SendWithUs.Client.Tests.csproj
@@ -78,7 +78,7 @@
     <Compile Include="Component\BatchRequestWrapperConverterTests.cs" />
     <Compile Include="Component\ComponentTestsBase.cs" />
     <Compile Include="EndToEnd\TestData.cs" />
-    <Compile Include="Component\JsonObjectWriter.cs" />
+    <Compile Include="Component\BufferedJsonStringWriter.cs" />
     <Compile Include="Component\SendRequestConverterTests.cs" />
     <Compile Include="EndToEnd\SendAsyncTests.cs" />
     <Compile Include="EndToEnd\BatchAsyncTests.cs" />

--- a/SendWithUs.Client.Tests/SendWithUs.Client.Tests.csproj
+++ b/SendWithUs.Client.Tests/SendWithUs.Client.Tests.csproj
@@ -1,0 +1,146 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C3059E9E-CE97-4E9B-B778-D78EFD1E448A}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SendWithUs.Client.Tests</RootNamespace>
+    <AssemblyName>SendWithUs.Client.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+    <NuGetPackageImportStamp>48b07db4</NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\packages\Newtonsoft.Json.6.0.6\lib\portable-net45+wp80+win8+wpa81+aspnetcore50\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Extensions">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Formatting">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.2\lib\portable-wp8+netcore45+net45+wp81+wpa81\System.Net.Http.Formatting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Net.Http.Primitives">
+      <HintPath>..\packages\Microsoft.Net.Http.2.2.22\lib\portable-net40+sl4+win8+wp71+wpa81\System.Net.Http.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.XML" />
+    <Reference Include="System.Xml.Linq" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="Component\BatchRequestWrapperConverterTests.cs" />
+    <Compile Include="Component\ComponentTestsBase.cs" />
+    <Compile Include="EndToEnd\TestData.cs" />
+    <Compile Include="Component\JsonObjectWriter.cs" />
+    <Compile Include="Component\SendRequestConverterTests.cs" />
+    <Compile Include="EndToEnd\SendAsyncTests.cs" />
+    <Compile Include="EndToEnd\BatchAsyncTests.cs" />
+    <Compile Include="Extensions.cs" />
+    <Compile Include="TestHelper.cs" />
+    <Compile Include="Unit\BaseResponseTests.cs" />
+    <Compile Include="Unit\BatchRequestWrapperConverterTests.cs" />
+    <Compile Include="Unit\BatchRequestWrapperTests.cs" />
+    <Compile Include="Unit\SendRequestConverterTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Unit\SendRequestTests.cs" />
+    <Compile Include="Unit\SendResponseTests.cs" />
+    <Compile Include="Unit\SendWithUsClientTests.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="EndToEnd\Data\SendRequest.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="EndToEnd\Data\mimeo-logo-black.png">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SendWithUs.Client\SendWithUs.Client.csproj">
+      <Project>{012b2a9e-8a75-4d6f-8051-eefbe9f6bad1}</Project>
+      <Name>SendWithUs.Client</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup />
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
+  </Target>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SendWithUs.Client.Tests/TestHelper.cs
+++ b/SendWithUs.Client.Tests/TestHelper.cs
@@ -1,0 +1,97 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public static class TestHelper
+    {
+        // NOTE: Use a fixed seed to aid in debugging.
+        private static readonly Random RandomNumber = new Random();
+
+        public static IEnumerable<T> Generate<T>(int count, Func<int, T> itemGenerator)
+        {
+            if (count < 0)
+            {
+                throw new ArgumentException("Count must be non-negative.");
+            }
+
+            return Enumerable.Range(0, count).Select(i => itemGenerator(i));
+        }
+
+        public static IEnumerable<T> Generate<T>(int min, int max, Func<int, T> itemGenerator)
+        {
+            if (max < min)
+            {
+                throw new ArgumentException("Max must be greater than or equal to min.");
+            }
+
+            return Enumerable.Range(min, max - min + 1).Select(i => itemGenerator(i));
+        }
+
+        public static Exception CaptureException(Action action)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception captured)
+            {
+                return captured;
+            }
+
+            return null;
+        }
+
+        public static Exception CaptureException(Func<Task> asyncAction)
+        {
+            try
+            {
+                asyncAction().Wait();
+            }
+            catch (AggregateException captured)
+            {
+                return captured.InnerException;
+            }
+
+            return null;
+        }
+
+        public static int GetRandomInteger(int min, int max)
+        {
+            return RandomNumber.Next(min, max);
+        }
+
+        public static string GetUniqueId()
+        {
+            return Guid.NewGuid().ToString("N");
+        }
+
+        public static IDictionary<string, object> GetRandomData()
+        {
+            var itemCount = GetRandomInteger(0, 10);
+            return Generate(itemCount, i => GetUniqueId()).ToDictionary<string ,string, object>(k => k, k => GetUniqueId());
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/BaseResponseTests.cs
+++ b/SendWithUs.Client.Tests/Unit/BaseResponseTests.cs
@@ -1,0 +1,172 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System.Linq;
+    using System.Net;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class BaseResponseTests
+    {
+        [TestMethod]
+        public void Initialize_Always_SetsStatusCode()
+        {
+            // Arrange
+            var statusCode = HttpStatusCode.OK;
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+
+            // Act
+            response.Object.Initialize(statusCode, null);
+
+            // Assert
+            response.VerifySet(r => r.StatusCode = statusCode, Times.Once);
+            Assert.AreEqual(response.Object.StatusCode, statusCode);
+        }
+
+        [TestMethod]
+        public void Initialize_SuccessStatusCode_CallsPopulate()
+        {
+            // Arrange
+            var statusCode = HttpStatusCode.OK;
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+
+            // Act
+            response.Object.Initialize(statusCode, jtoken);
+
+            // Assert
+            response.Verify(r => r.IsSuccessStatusCode(), Times.Once);
+            response.Verify(r => r.Populate(jtoken), Times.Once);
+            response.Verify(r => r.SetErrorMessage(It.IsAny<JValue>()), Times.Never);
+        }
+
+
+        [TestMethod]
+        public void Initialize_NonSuccessStatusCode_CallsSetErrorMessage()
+        {
+            // Arrange
+            var statusCode = HttpStatusCode.BadRequest;
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+
+            // Act
+            response.Object.Initialize(statusCode, jtoken);
+
+            // Assert
+            response.Verify(r => r.IsSuccessStatusCode(), Times.Once);
+            response.Verify(r => r.Populate(jtoken), Times.Never);
+            response.Verify(r => r.SetErrorMessage(It.IsAny<JValue>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void IsSuccessStatusCode_StatusCodeInRange200To299_ReturnsTrue()
+        {
+            // Arrange
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+
+            // Act
+            var result = TestHelper.Generate<bool>(200, 299, (i) =>
+            {
+                response.Object.StatusCode = (HttpStatusCode)i;
+                return response.Object.IsSuccessStatusCode();
+            });
+
+            // Assert
+            Assert.IsTrue(result.All(v => v == true));
+        }
+
+        [TestMethod]
+        public void IsSuccessStatusCode_StatusCodeLessThan200_ReturnsFalse()
+        {
+            // Arrange
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+
+            // Act
+            var result = TestHelper.Generate<bool>(100, 199, (i) =>
+            {
+                response.Object.StatusCode = (HttpStatusCode)i;
+                return response.Object.IsSuccessStatusCode();
+            }).ToList();
+
+            // Assert
+            Assert.IsTrue(result.All(v => v == false));
+        }
+
+        [TestMethod]
+        public void IsSuccessStatusCode_StatusCodeGreaterThan299_ReturnsFalse()
+        {
+            // Arrange
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+
+            // Act
+            var result = TestHelper.Generate<bool>(300, 599, (i) =>
+            {
+                response.Object.StatusCode = (HttpStatusCode)i;
+                return response.Object.IsSuccessStatusCode();
+            });
+
+            // Assert
+            Assert.IsTrue(result.All(v => v == false));
+        }
+
+        [TestMethod]
+        public void SetErrorMessage_NullValue_UsesStatusCode()
+        {
+            // Arrange
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+            var statusCode = HttpStatusCode.OK;
+            var statusString = statusCode.ToString();
+            var value = null as JValue;
+
+            response.SetupGet(r => r.StatusCode).Returns(statusCode);
+
+            // Act
+            response.Object.SetErrorMessage(value);
+
+            // Assert
+            response.VerifySet(r => r.ErrorMessage = statusString, Times.Once);
+        }
+
+
+        [TestMethod]
+        public void SetErrorMessage_NonNullValue_UsesValue()
+        {
+            // Arrange
+            var jtoken = new JObject();
+            var response = new Mock<BaseResponse<JToken>>() { CallBase = true };
+            var valueString = TestHelper.GetUniqueId();
+            var value = new JValue(valueString);
+
+            // Act
+            response.Object.SetErrorMessage(value);
+
+            // Assert
+            response.VerifySet(r => r.ErrorMessage = valueString, Times.Once);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/BatchRequestWrapperConverterTests.cs
+++ b/SendWithUs.Client.Tests/Unit/BatchRequestWrapperConverterTests.cs
@@ -1,0 +1,258 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json;
+    using Names = BatchRequestWrapperConverter.PropertyNames;
+
+    [TestClass]
+    public class BatchRequestWrapperConverterTests
+    {
+        internal class BatchRequestWrapperSubtype : BatchRequestWrapper
+        { 
+            internal BatchRequestWrapperSubtype() : base(null)
+            { }
+        }
+
+        public class NonBatchRequestWrapper
+        { }
+
+        [TestMethod]
+        public void CanRead_Getter_ReturnsFalse()
+        {
+            // Arrange
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act 
+            var canRead = converter.CanRead;
+
+            // Assert
+            Assert.IsFalse(canRead);
+        }
+
+        [TestMethod]
+        public void CanWrite_Getter_ReturnsTrue()
+        {
+            // Arrange
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act 
+            var canRead = converter.CanWrite;
+
+            // Assert
+            Assert.IsTrue(canRead);
+        }
+
+        [TestMethod]
+        public void CanConvert_BatchRequestWrapperType_ReturnsTrue()
+        {
+            // Arrange
+            var type = typeof(BatchRequestWrapper);
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var canConvert = converter.CanConvert(type);
+
+            // Assert
+            Assert.IsTrue(canConvert);
+        }
+
+        [TestMethod]
+        public void CanConvert_BatchRequestWrapperSubtype_ReturnsTrue()
+        {
+            // Arrange
+            var type = typeof(BatchRequestWrapperSubtype);
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var canConvert = converter.CanConvert(type);
+
+            // Assert
+            Assert.IsTrue(canConvert);
+        }
+
+        [TestMethod]
+        public void CanConvert_NonBatchRequestWrapperType_ReturnsFalse()
+        {
+            // Arrange
+            var type = typeof(NonBatchRequestWrapper);
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var canConvert = converter.CanConvert(type);
+
+            // Assert
+            Assert.IsFalse(canConvert);
+        }
+
+        [TestMethod]
+        public void ReadJson_Always_Throws()
+        {
+            // Arrange
+            var reader = new Mock<JsonReader>().Object;
+            var serializer = new Mock<JsonSerializer>().Object;
+            var inner = new Mock<IRequest>();
+            var wrapper = new BatchRequestWrapper(inner.Object);
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.ReadJson(reader, wrapper.GetType(), wrapper, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(NotImplementedException));
+        }
+
+        [TestMethod]
+        public void WriteJson_NullWriter_Throws()
+        {
+            // Arrange
+            var serializer = new Mock<JsonSerializer>().Object;
+            var inner = new Mock<IRequest>();
+            var wrapper = new BatchRequestWrapper(inner.Object);
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.WriteJson(null, wrapper, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        public void WriteJson_NullSerializer_Throws()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>().Object;
+            var inner = new Mock<IRequest>();
+            var wrapper = new BatchRequestWrapper(inner.Object);
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.WriteJson(writer, wrapper, null));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        public void WriteJson_NonBatchRequestWrapperValue_Throws()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>().Object;
+            var serializer = new Mock<JsonSerializer>().Object;
+            var value = new NonBatchRequestWrapper();
+            var converter = new BatchRequestWrapperConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.WriteJson(writer, value, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentException));
+        }
+
+        [TestMethod]
+        public void WriteJson_Normally_WritesJsonObject()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<JsonSerializer>();
+            var inner = new Mock<IRequest>();
+            var wrapper = new Mock<BatchRequestWrapper>(inner.Object);
+            var converter = new BatchRequestWrapperConverter();
+
+            inner.SetupAllProperties();
+
+            // Act
+            converter.WriteJson(writer.Object, wrapper.Object, serializer.Object);
+
+            // Assert
+            writer.Verify(w => w.WriteStartObject(), Times.Once);
+            writer.Verify(w => w.WriteEndObject(), Times.Once);
+        }
+
+        [TestMethod]
+        public void WriteJson_Normally_SerializesWrapperPath()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<JsonSerializer>();
+            var inner = new Mock<IRequest>();
+            var wrapper = new Mock<BatchRequestWrapper>(inner.Object);
+            var path = TestHelper.GetUniqueId();
+            var converter = new BatchRequestWrapperConverter();
+
+            inner.SetupAllProperties();
+            wrapper.SetupGet(w => w.Path).Returns(path);
+
+            // Act
+            converter.WriteJson(writer.Object, wrapper.Object, serializer.Object);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(Names.Path), Times.Once);
+            writer.Verify(s => s.WriteValue(wrapper.Object.Path), Times.Once);
+        }
+
+        [TestMethod]
+        public void WriteJson_Normally_SerializesWrapperMethod()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<JsonSerializer>();
+            var inner = new Mock<IRequest>();
+            var wrapper = new Mock<BatchRequestWrapper>(inner.Object);
+            var method = TestHelper.GetUniqueId();
+            var converter = new BatchRequestWrapperConverter();
+
+            inner.SetupAllProperties();
+            wrapper.SetupGet(w => w.Method).Returns(method);
+
+            // Act
+            converter.WriteJson(writer.Object, wrapper.Object, serializer.Object);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(Names.Method), Times.Once);
+            writer.Verify(s => s.WriteValue(method), Times.Once);
+        }
+
+        [TestMethod]
+        public void WriteJson_Normally_SerializesWrapperInnerRequest()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var inner = new Mock<IRequest>();
+            var wrapper = new Mock<BatchRequestWrapper>(inner.Object);
+            var converter = new BatchRequestWrapperConverter();
+
+            wrapper.SetupGet(w => w.InnerRequest).Returns(inner.Object);
+
+            // Act
+            converter.WriteJson(writer.Object, wrapper.Object, serializer.Object);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(Names.InnerRequest), Times.Once);
+            serializer.Verify(s => s.Serialize(writer.Object, inner.Object), Times.Once);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/BatchRequestWrapperTests.cs
+++ b/SendWithUs.Client.Tests/Unit/BatchRequestWrapperTests.cs
@@ -1,0 +1,71 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class BatchRequestWrapperTests
+    {
+        [TestMethod]
+        public void Ctor_NullInnerRequest_Throws()
+        {
+            // Arrange
+            var inner = null as IRequest;
+
+            // Act
+            var exception = TestHelper.CaptureException(() => new BatchRequestWrapper(inner));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        public void Method_Getter_CallsInnerRequestGetHttpMethod()
+        {
+            // Arrange
+            var inner = new Mock<IRequest>();
+            var wrapper = new BatchRequestWrapper(inner.Object);
+
+            // Act
+            var method = wrapper.Method;
+
+            // Assert
+            inner.Verify(i => i.GetHttpMethod(), Times.Once);
+        }
+
+        [TestMethod]
+        public void Path_Getter_CallsInnerRequestGetUriPath()
+        {
+            // Arrange
+            var inner = new Mock<IRequest>();
+            var wrapper = new BatchRequestWrapper(inner.Object);
+
+            // Act
+            var method = wrapper.Path;
+
+            // Assert
+            inner.Verify(i => i.GetUriPath(), Times.Once);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/SendRequestConverterTests.cs
+++ b/SendWithUs.Client.Tests/Unit/SendRequestConverterTests.cs
@@ -1,0 +1,368 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json;
+    using SendWithUs.Client;
+    using Names = SendRequestConverter.PropertyNames;
+
+    [TestClass]
+    public class SendRequestConverterTests
+    {
+        public class NonSendRequest { }
+
+        public interface ISendRequestSubtype : ISendRequest { }
+
+        [TestMethod]
+        public void CanRead_Getter_ReturnsFalse()
+        {
+            // Arrange
+            var converter = new SendRequestConverter();
+
+            // Act 
+            var canRead = converter.CanRead;
+
+            // Assert
+            Assert.IsFalse(canRead);
+        }
+
+        [TestMethod]
+        public void CanWrite_Getter_ReturnsTrue()
+        {
+            // Arrange
+            var converter = new SendRequestConverter();
+
+            // Act 
+            var canWrite = converter.CanWrite;
+
+            // Assert
+            Assert.IsTrue(canWrite);
+        }
+
+        [TestMethod]
+        public void CanConvert_ISendRequestType_ReturnsTrue()
+        {
+            // Arrange
+            var type = typeof(ISendRequest);
+            var converter = new SendRequestConverter();
+
+            // Act
+            var canConvert = converter.CanConvert(type);
+
+            // Assert
+            Assert.IsTrue(canConvert);
+        }
+
+        [TestMethod]
+        public void CanConvert_ISendRequestSubtype_ReturnsTrue()
+        {
+            // Arrange
+            var type = typeof(ISendRequestSubtype);
+            var converter = new SendRequestConverter();
+
+            // Act
+            var canConvert = converter.CanConvert(type);
+
+            // Assert
+            Assert.IsTrue(canConvert);
+        }
+
+        [TestMethod]
+        public void CanConvert_NonISendRequestType_ReturnsFalse()
+        {
+            // Arrange
+            var type = typeof(NonSendRequest);
+            var converter = new SendRequestConverter();
+
+            // Act
+            var canConvert = converter.CanConvert(type);
+
+            // Assert
+            Assert.IsFalse(canConvert);
+        }
+
+        [TestMethod]
+        public void ReadJson_Always_Throws()
+        {
+            // Arrange
+            var reader = new Mock<JsonReader>().Object;
+            var serializer = new Mock<JsonSerializer>().Object;
+            var request = new Mock<ISendRequest>().Object;
+            var converter = new SendRequestConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.ReadJson(reader, request.GetType(), request, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(NotImplementedException));
+        }
+
+        [TestMethod]
+        public void WriteJson_NullWriter_Throws()
+        {
+            // Arrange
+            var serializer = new Mock<SerializerProxy>(null).Object;
+            var request = new Mock<ISendRequest>().Object;
+            var converter = new SendRequestConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.WriteJson(null, request, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        public void WriteJson_NullSerializer_Throws()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>().Object;
+            var serializer = null as SerializerProxy;
+            var request = new Mock<ISendRequest>().Object;
+            var converter = new SendRequestConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.WriteJson(writer, request, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        [TestMethod]
+        public void WriteJson_NonISendRequestValue_Throws()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>().Object;
+            var serializer = new Mock<SerializerProxy>(null).Object;
+            var value = new NonSendRequest();
+            var converter = new SendRequestConverter();
+
+            // Act
+            var exception = TestHelper.CaptureException(() => converter.WriteJson(writer, value, serializer));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentException));
+        }
+
+        [TestMethod]
+        public void WriteJson_Normally_WritesObject()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new SendRequestConverter();
+
+            // Act
+            converter.WriteJson(writer.Object, request.Object, serializer.Object);
+
+            // Assert
+            writer.Verify(w => w.WriteStartObject(), Times.AtLeastOnce);
+            writer.Verify(w => w.WriteEndObject(), Times.AtLeastOnce);
+        }
+
+        [TestMethod]
+        public void WriteJson_Normally_CallsHelpers()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new Mock<SendRequestConverter>() { CallBase = true };
+            var templateId = TestHelper.GetUniqueId();
+            var providerId = TestHelper.GetUniqueId();
+            var templateVersionId = TestHelper.GetUniqueId();
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.ProviderId).Returns(providerId);
+            request.SetupGet(r => r.TemplateVersionId).Returns(templateVersionId);
+            
+            // Act
+            converter.Object.WriteJson(writer.Object, request.Object, serializer.Object);
+
+            // Assert
+            converter.Verify(c => c.WriteProperty(writer.Object, serializer.Object, Names.TemplateId, templateId, false), Times.Once);
+            converter.Verify(c => c.WriteProperty(writer.Object, serializer.Object, Names.ProviderId, providerId, true), Times.Once);
+            converter.Verify(c => c.WriteProperty(writer.Object, serializer.Object, Names.TemplateVersionId, templateVersionId, true), Times.Once);
+            converter.Verify(c => c.WriteEmailData(writer.Object, serializer.Object, request.Object), Times.Once);
+            converter.Verify(c => c.WritePrimaryRecipient(writer.Object, serializer.Object, request.Object), Times.Once);
+            converter.Verify(c => c.WriteCcRecipients(writer.Object, serializer.Object, request.Object), Times.Once);
+            converter.Verify(c => c.WriteBccRecipients(writer.Object, serializer.Object, request.Object), Times.Once);
+            converter.Verify(c => c.WriteTags(writer.Object, serializer.Object, request.Object), Times.Once);
+            converter.Verify(c => c.WriteInlineAttachment(writer.Object, serializer.Object, request.Object), Times.Once);
+            converter.Verify(c => c.WriteFileAttachments(writer.Object, serializer.Object, request.Object), Times.Once);
+        }
+
+        [TestMethod]
+        public void WritePrimaryRecipient_Normally_WritesObjectValuedProperty()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new SendRequestConverter();
+
+            // Act
+            converter.WritePrimaryRecipient(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(Names.Recipient));
+            writer.Verify(w => w.WriteStartObject());
+            writer.Verify(w => w.WriteEndObject());
+        }
+
+        [TestMethod]
+        public void WritePrimaryRecipient_Normally_CallsHelpers()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new Mock<SendRequestConverter>() { CallBase = true };
+            var recipientName = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+
+            request.SetupGet(r => r.RecipientName).Returns(recipientName);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+
+            // Act
+            converter.Object.WritePrimaryRecipient(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            converter.Verify(c => c.WriteProperty(writer.Object, serializer.Object, Names.Name, recipientName, true));
+            converter.Verify(c => c.WriteProperty(writer.Object, serializer.Object, Names.Address, recipientAddress, false));
+        }
+
+        [TestMethod]
+        public void WriteEmailData_NullData_DoesNotWrite()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new SendRequestConverter();
+
+            request.SetupGet(r => r.Data).Returns(null);
+
+            // Act
+            converter.WriteEmailData(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(It.IsAny<string>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void WriteEmailData_Normally_WritesPropertyName()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new SendRequestConverter();
+            var data = true; //TestHelper.GetRandomData();
+
+            request.SetupGet(r => r.Data).Returns(data);
+
+            // Act
+            converter.WriteEmailData(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(Names.Data), Times.Once);
+        }
+
+        [TestMethod]
+        public void WriteEmailData_Normally_SerializesData()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new SendRequestConverter();
+            var data = true; //TestHelper.GetRandomData();
+
+            request.SetupGet(r => r.Data).Returns(data);
+
+            // Act
+            converter.WriteEmailData(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            serializer.Verify(s => s.Serialize(writer.Object, data), Times.Once);
+        }
+
+        [TestMethod]
+        public void WriteCcRecipients_Always_CallsWriteRecipientsList()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new Mock<SendRequestConverter>() { CallBase = true };
+            var recipients = new List<string>();
+
+            request.SetupGet(r => r.CopyTo).Returns(recipients);
+
+            // Act
+            converter.Object.WriteCcRecipients(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            converter.Verify(c => c.WriteRecipientsList(writer.Object, serializer.Object, Names.CopyTo, recipients));
+        }
+
+        [TestMethod]
+        public void WriteBccRecipients_Always_CallsWriteRecipientsList()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var request = new Mock<ISendRequest>();
+            var converter = new Mock<SendRequestConverter>() { CallBase = true };
+            var recipients = new List<string>();
+
+            request.SetupGet(r => r.CopyTo).Returns(recipients);
+
+            // Act
+            converter.Object.WriteBccRecipients(writer.Object, serializer.Object, request.Object);
+
+            // Assert
+            converter.Verify(c => c.WriteRecipientsList(writer.Object, serializer.Object, Names.BlindCopyTo, recipients));
+        }
+
+        [TestMethod]
+        public void WriteRecipientsList_NullRecipients_DoesNotWrite()
+        {
+            // Arrange
+            var writer = new Mock<JsonWriter>();
+            var serializer = new Mock<SerializerProxy>(null);
+            var converter = new SendRequestConverter();
+            var name = TestHelper.GetUniqueId();
+
+            // Act
+            converter.WriteRecipientsList(writer.Object, serializer.Object, name, null);
+
+            // Assert
+            writer.Verify(w => w.WritePropertyName(name), Times.Never);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/SendRequestTests.cs
+++ b/SendWithUs.Client.Tests/Unit/SendRequestTests.cs
@@ -1,0 +1,220 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class SendRequestTests
+    {
+        [TestMethod]
+        public void IsValid_Getter_CallsValidate()
+        {
+            // Arrange
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            // Act
+            var isValid = request.Object.IsValid;
+
+            // Assert
+            request.Verify(r => r.Validate(false), Times.Once);
+        }
+
+        [TestMethod]
+        public void GetResponseType_Always_ReturnsSendResponseType()
+        {
+            // Arrange
+            var request = new SendRequest();
+
+            // Act
+            var responseType = request.GetResponseType();
+
+            // Assert
+            Assert.AreEqual(typeof(SendResponse), responseType);
+        }
+
+        [TestMethod]
+        public void Validate_Always_CallsValidateBool()
+        {
+            // Arrange
+            var request = new Mock<SendRequest>();
+
+            // Act
+            var self = request.Object.Validate();
+
+            // Assert
+            request.Verify(r => r.Validate(true), Times.Once);
+        }
+
+        [TestMethod]
+        public void Validate_Always_ReturnsSelf()
+        {
+            // Arrange
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var request = new SendRequest(templateId, recipientAddress);
+
+            // Act
+            var self = request.Validate();
+
+            // Assert
+            Assert.AreSame(request, self);
+        }
+
+        [TestMethod]
+        public void ValidateBool_Normally_ReturnsTrue()
+        {
+            // Arrange
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+
+            // Act
+            var isValid = request.Object.Validate(false);
+
+            // Assert
+            Assert.IsTrue(isValid);
+        }
+
+        [TestMethod]
+        public void ValidateBool_TrueFlagAndEmptyTemplateId_Throws()
+        {
+            // Arrange
+            var templateId = String.Empty;
+            var recipientAddress = TestHelper.GetUniqueId();
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+
+            // Act
+            var exception = TestHelper.CaptureException(() => request.Object.Validate(true));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ValidationException));
+            var invalid = exception as ValidationException;
+            Assert.AreEqual(ValidationFailureMode.MissingTemplateId, invalid.FailureMode);
+        }
+
+        [TestMethod]
+        public void ValidateBool_TrueFlagAndEmptyRecipientAddress_Throws()
+        {
+            // Arrange
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = String.Empty;
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+
+            // Act
+            var exception = TestHelper.CaptureException(() => request.Object.Validate(true));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ValidationException));
+            var invalid = exception as ValidationException;
+            Assert.AreEqual(ValidationFailureMode.MissingRecipientAddress, invalid.FailureMode);
+        }
+
+        [TestMethod]
+        public void ValidateBool_TrueFlagAndInconsistentSenderValues_Throws()
+        {
+            // Arrange
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var senderName = TestHelper.GetUniqueId();
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+            request.SetupGet(r => r.SenderName).Returns(senderName);
+
+            // Act
+            var exception = TestHelper.CaptureException(() => request.Object.Validate(true));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ValidationException));
+            var invalid = exception as ValidationException;
+            Assert.AreEqual(ValidationFailureMode.MissingSenderAddress, invalid.FailureMode);
+        }
+
+        [TestMethod]
+        public void ValidateBool_FalseFlagAndEmptyTemplateId_ReturnsFalse()
+        {
+            // Arrange
+            var templateId = String.Empty;
+            var recipientAddress = TestHelper.GetUniqueId();
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+
+            // Act
+            var isValid =  request.Object.Validate(false);
+
+            // Assert
+            Assert.AreEqual(false, isValid);
+        }
+
+        [TestMethod]
+        public void ValidateBool_FalseFlagAndEmptyRecipientAddress_ReturnsFalse()
+        {
+            // Arrange
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = String.Empty;
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+
+            // Act
+            var isValid = request.Object.Validate(false);
+
+            // Assert
+            Assert.AreEqual(false, isValid);
+        }
+
+        [TestMethod]
+        public void ValidateBool_FalseFlagAndInconsistentSenderValues_ReturnsFalse()
+        {
+            // Arrange
+            var templateId = TestHelper.GetUniqueId();
+            var recipientAddress = TestHelper.GetUniqueId();
+            var senderName = TestHelper.GetUniqueId();
+            var request = new Mock<SendRequest>() { CallBase = true };
+
+            request.SetupGet(r => r.TemplateId).Returns(templateId);
+            request.SetupGet(r => r.RecipientAddress).Returns(recipientAddress);
+            request.SetupGet(r => r.SenderName).Returns(senderName);
+
+            // Act
+            var isValid = request.Object.Validate(false);
+
+            // Assert
+            Assert.AreEqual(false, isValid);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/SendResponseTests.cs
+++ b/SendWithUs.Client.Tests/Unit/SendResponseTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Text;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Newtonsoft.Json.Linq;
+    using Names = SendWithUs.Client.SendResponse.PropertyNames;
+
+    [TestClass]
+    public class SendResponseTests
+    {
+        [TestMethod]
+        public void Populate_NullJson_DoesNotSetProperties()
+        {
+            // Arrange
+            var response = new Mock<SendResponse>() { CallBase = true };
+            var json = null as JObject;
+
+            // Act
+            response.Object.Populate(json);
+
+            // Assert
+            response.VerifySet(r => r.Success = It.IsAny<bool>(), Times.Never);
+            response.VerifySet(r => r.Status = It.IsAny<string>(), Times.Never);
+            response.VerifySet(r => r.ReceiptId = It.IsAny<string>(), Times.Never);
+            response.VerifySet(r => r.TemplateName = It.IsAny<string>(), Times.Never);
+            response.VerifySet(r => r.TemplateVersionId = It.IsAny<string>(), Times.Never);
+        }
+
+        [TestMethod]
+        public void Populate_ValidJson_SetsProperties()
+        {
+            // Arrange
+            var response = new Mock<SendResponse>() { CallBase = true };
+            var success = true;
+            var status = TestHelper.GetUniqueId();
+            var receiptId = TestHelper.GetUniqueId();
+            var templateName = TestHelper.GetUniqueId();
+            var templateVersionId = TestHelper.GetUniqueId();
+            var json = new Mock<JObject>();
+            var details = new Mock<JObject>();
+
+            json.Setup(j => j.Value<bool>(Names.Success)).Returns(success);
+            json.Setup(j => j.Value<string>(Names.Status)).Returns(status);
+            json.Setup(j => j.Value<string>(Names.ReceiptId)).Returns(receiptId);
+            response.Setup(r => r.GetPropertyValue(json.Object, Names.Details)).Returns(details.Object);
+            details.Setup(d => d.Value<string>(Names.TemplateName)).Returns(templateName);
+            details.Setup(d => d.Value<string>(Names.TemplateVersionId)).Returns(templateVersionId);
+
+            // Act
+            response.Object.Populate(json.Object);
+
+            // Assert
+            response.VerifySet(r => r.Success = success, Times.Once);
+            response.VerifySet(r => r.Status = status, Times.Once);
+            response.VerifySet(r => r.ReceiptId = receiptId, Times.Once);
+            response.VerifySet(r => r.TemplateName = templateName, Times.Once);
+            response.VerifySet(r => r.TemplateVersionId = templateVersionId, Times.Once);
+        }
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/SendWithUsClientTests.cs
+++ b/SendWithUs.Client.Tests/Unit/SendWithUsClientTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright © 2015 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client.Tests.Unit
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using SendWithUs.Client;
+
+    [TestClass]
+    public class SendWithUsClientTests
+    {
+        #region SendAsync
+
+        [TestMethod]
+        public void SendAsync_NullRequest_Throws()
+        {
+            // Arrange
+            var apiKey = TestHelper.GetUniqueId();
+            var client = new SendWithUsClient(apiKey);
+
+            // Act
+            var exception = TestHelper.CaptureException(() => client.SendAsync(null));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        #endregion
+
+        #region BatchAsync
+
+        [TestMethod]
+        public void BatchAsync_NullRequest_Throws()
+        {
+            // Arrange
+            var apiKey = TestHelper.GetUniqueId();
+            var client = new SendWithUsClient(apiKey);
+
+            // Act
+            var exception = TestHelper.CaptureException(() => client.BatchAsync(null));
+
+            // Assert
+            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+        }
+
+        #endregion
+    }
+}

--- a/SendWithUs.Client.Tests/Unit/SendWithUsClientTests.cs
+++ b/SendWithUs.Client.Tests/Unit/SendWithUsClientTests.cs
@@ -58,7 +58,7 @@ namespace SendWithUs.Client.Tests.Unit
             var exception = TestHelper.CaptureException(() => client.BatchAsync(null));
 
             // Assert
-            Assert.IsInstanceOfType(exception, typeof(ArgumentNullException));
+            Assert.IsInstanceOfType(exception, typeof(ArgumentException));
         }
 
         #endregion

--- a/SendWithUs.Client.Tests/packages.config
+++ b/SendWithUs.Client.Tests/packages.config
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Microsoft.Bcl" version="1.1.9" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
+  <package id="Microsoft.Net.Http" version="2.2.22" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+  <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.6" targetFramework="portable-net45+win+wp80+MonoAndroid10+MonoTouch10" />
+</packages>

--- a/SendWithUs.Client.sln
+++ b/SendWithUs.Client.sln
@@ -10,6 +10,15 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E293AC
 		.nuget\NuGet.Config = .nuget\NuGet.Config
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9C467463-89F4-4727-9049-3D80D8AF1E8E}"
+	ProjectSection(SolutionItems) = preProject
+		.gitignore = .gitignore
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SendWithUs.Client.Tests", "SendWithUs.Client.Tests\SendWithUs.Client.Tests.csproj", "{C3059E9E-CE97-4E9B-B778-D78EFD1E448A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +29,10 @@ Global
 		{012B2A9E-8A75-4D6F-8051-EEFBE9F6BAD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{012B2A9E-8A75-4D6F-8051-EEFBE9F6BAD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{012B2A9E-8A75-4D6F-8051-EEFBE9F6BAD1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C3059E9E-CE97-4E9B-B778-D78EFD1E448A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C3059E9E-CE97-4E9B-B778-D78EFD1E448A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C3059E9E-CE97-4E9B-B778-D78EFD1E448A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C3059E9E-CE97-4E9B-B778-D78EFD1E448A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SendWithUs.Client/Helpers/EnsureArgument.cs
+++ b/SendWithUs.Client/Helpers/EnsureArgument.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2014 Mimeo, Inc.
+﻿// Copyright © 2015 Mimeo, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,31 +20,43 @@
 
 namespace SendWithUs.Client
 {
-    using Newtonsoft.Json;
+    using System;
+    using System.Globalization;
 
-    /// <summary>
-    /// Wraps an IRequest object for use in a batch request.
-    /// </summary>
-    /// <remarks>This class MUST NOT implement IRequest.</remarks>
-    [JsonConverter(typeof(BatchRequestWrapperConverter))]
-    public class BatchRequestWrapper
+    public static class EnsureArgument
     {
-        public virtual string Method
+        public static void NotNull(object value, string paramName)
         {
-            get { return this.InnerRequest.GetHttpMethod(); }
+            if (value == null)
+            {
+                throw new ArgumentNullException(paramName);
+            }
         }
 
-        public virtual string Path
+        public static void NotNullOrEmpty(string value, string paramName)
         {
-            get { return this.InnerRequest.GetUriPath(); }
+            if (String.IsNullOrEmpty(value))
+            {
+                throw new ArgumentNullException(paramName);
+            }
         }
 
-        public virtual IRequest InnerRequest { get; protected set; }
-
-        public BatchRequestWrapper(IRequest innerRequest)
+        public static T Of<T>(object value, string paramName) where T : class
         {
-            EnsureArgument.NotNull(innerRequest, "innerRequest");
-            this.InnerRequest = innerRequest;
+            return EnsureArgument.Of<T>(value, paramName, String.Format(CultureInfo.InvariantCulture, 
+                "The value of '{0}' must be of type '{1}'.", paramName, typeof(T)));
+        }
+
+        public static T Of<T>(object value, string paramName, string errorMessage) where T : class
+        {
+            var typedValue = value as T;
+
+            if (typedValue == null)
+            {
+                throw new ArgumentException(errorMessage, paramName);
+            }
+
+            return typedValue;
         }
     }
 }

--- a/SendWithUs.Client/Helpers/EnsureArgument.cs
+++ b/SendWithUs.Client/Helpers/EnsureArgument.cs
@@ -39,7 +39,7 @@ namespace SendWithUs.Client
         {
             if (String.IsNullOrEmpty(value))
             {
-                throw new ArgumentNullException(paramName);
+                throw new ArgumentException("Argument is null or empty.", paramName);
             }
         }
 
@@ -47,7 +47,8 @@ namespace SendWithUs.Client
         {
             if (value == null || value.Count() == 0 || (!allowNullItems && value.Any(i => i == null)))
             {
-                throw new ArgumentNullException(paramName);
+                var message = allowNullItems ? "Argument is null or empty." : "Argument is null, empty, or contains a null item.";
+                throw new ArgumentException(message, paramName);
             }
         }
 

--- a/SendWithUs.Client/Helpers/EnsureArgument.cs
+++ b/SendWithUs.Client/Helpers/EnsureArgument.cs
@@ -21,7 +21,9 @@
 namespace SendWithUs.Client
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
 
     public static class EnsureArgument
     {
@@ -36,6 +38,14 @@ namespace SendWithUs.Client
         public static void NotNullOrEmpty(string value, string paramName)
         {
             if (String.IsNullOrEmpty(value))
+            {
+                throw new ArgumentNullException(paramName);
+            }
+        }
+
+        public static void NotNullOrEmpty<TItem>(IEnumerable<TItem> value, string paramName, bool allowNullItems)
+        {
+            if (value == null || value.Count() == 0 || (!allowNullItems && value.Any(i => i == null)))
             {
                 throw new ArgumentNullException(paramName);
             }

--- a/SendWithUs.Client/Helpers/SerializerProxy.cs
+++ b/SendWithUs.Client/Helpers/SerializerProxy.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2014 Mimeo, Inc.
+﻿// Copyright © 2015 Mimeo, Inc.
 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -23,28 +23,32 @@ namespace SendWithUs.Client
     using Newtonsoft.Json;
 
     /// <summary>
-    /// Wraps an IRequest object for use in a batch request.
+    /// Provides a mockable proxy over JsonSerializer.
     /// </summary>
-    /// <remarks>This class MUST NOT implement IRequest.</remarks>
-    [JsonConverter(typeof(BatchRequestWrapperConverter))]
-    public class BatchRequestWrapper
+    public class SerializerProxy
     {
-        public virtual string Method
+        /// <summary>
+        /// Gets or sets the serializer implementation.
+        /// </summary>
+        protected JsonSerializer Implementation { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the SerializerProxy class.
+        /// </summary>
+        /// <param name="implementation">The serializer implementation.</param>
+        public SerializerProxy(JsonSerializer implementation)
         {
-            get { return this.InnerRequest.GetHttpMethod(); }
+            this.Implementation = implementation;
         }
 
-        public virtual string Path
+        /// <summary>
+        /// Serializes the specified object and writes the Json structure to a Stream using the specified JsonWriter.
+        /// </summary>
+        /// <param name="writer">The JsonWriter used to write the Json structure.</param>
+        /// <param name="value">The object to serialize.</param>
+        public virtual void Serialize(JsonWriter writer, object value)
         {
-            get { return this.InnerRequest.GetUriPath(); }
-        }
-
-        public virtual IRequest InnerRequest { get; protected set; }
-
-        public BatchRequestWrapper(IRequest innerRequest)
-        {
-            EnsureArgument.NotNull(innerRequest, "innerRequest");
-            this.InnerRequest = innerRequest;
+            this.Implementation.Serialize(writer, value);
         }
     }
 }

--- a/SendWithUs.Client/Helpers/ValidationFailureMode.cs
+++ b/SendWithUs.Client/Helpers/ValidationFailureMode.cs
@@ -25,7 +25,6 @@ namespace SendWithUs.Client
         None,
         MissingTemplateId,
         MissingRecipientAddress,
-        MissingSenderAddress,
-        NullInnerRequest
+        MissingSenderAddress
     }
 }

--- a/SendWithUs.Client/ISendWithUsClient.cs
+++ b/SendWithUs.Client/ISendWithUsClient.cs
@@ -1,0 +1,14 @@
+﻿// Copyright © 2015 Mimeo, Inc. All rights reserved.
+
+namespace SendWithUs.Client
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public interface ISendWithUsClient
+    {
+        Task<ISendResponse> SendAsync(ISendRequest request);
+
+        Task<IBatchResponse> BatchAsync(IEnumerable<IRequest> requests);
+    }
+}

--- a/SendWithUs.Client/Properties/AssemblyInfo.cs
+++ b/SendWithUs.Client/Properties/AssemblyInfo.cs
@@ -35,6 +35,6 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
-[assembly: AssemblyVersion("0.1.0.*")]
-[assembly: AssemblyInformationalVersion("0.1.0")]
+[assembly: AssemblyVersion("0.2.0.*")]
+[assembly: AssemblyInformationalVersion("0.2.0")]
 [assembly: InternalsVisibleTo("SendWithUs.Client.Tests")]

--- a/SendWithUs.Client/Requests/ISendRequest.cs
+++ b/SendWithUs.Client/Requests/ISendRequest.cs
@@ -76,7 +76,7 @@ namespace SendWithUs.Client
         /// Gets the data to use when expanding the message template.
         /// </summary>
         /// <remarks>Corresponds to the "email_data" property in the SendWithUs API.</remarks>
-        IDictionary<string, string> Data { get; }
+        object Data { get; }
 
         /// <summary>
         /// Gets the set of tags to associate with the message.

--- a/SendWithUs.Client/Requests/SendRequest.cs
+++ b/SendWithUs.Client/Requests/SendRequest.cs
@@ -163,7 +163,7 @@ namespace SendWithUs.Client
         public SendRequest(string templateId, string recipientAddress) : base(templateId, recipientAddress)
         { }
 
-        public SendRequest(string templateId, string recipientAddress, object data) : base(templateId, recipientAddress, data)
+        public SendRequest(string templateId, string recipientAddress, TData data) : base(templateId, recipientAddress, data)
         { }
 
         #endregion

--- a/SendWithUs.Client/Requests/SendRequest.cs
+++ b/SendWithUs.Client/Requests/SendRequest.cs
@@ -34,64 +34,55 @@ namespace SendWithUs.Client
     {
         #region Constructors
 
-        public SendRequest(string templateId, string recipientAddress) : this(templateId, recipientAddress, null)
-        {}
+        public SendRequest()
+        { }
 
-        public SendRequest(string templateId, string recipientAddress, IDictionary<string, string> data)
+        public SendRequest(string templateId, string recipientAddress) : this(templateId, recipientAddress, null)
+        { }
+
+        public SendRequest(string templateId, string recipientAddress, object data)
         {
+            EnsureArgument.NotNullOrEmpty(templateId, "templateId");
+            EnsureArgument.NotNullOrEmpty(recipientAddress, "recipientAddress");
+
             this.TemplateId = templateId;
             this.RecipientAddress = recipientAddress;
             this.Data = data;
-        }
-
-        public SendRequest(ISendRequest source) : this(source.TemplateId, source.RecipientAddress, source.Data)
-        {
-            this.SenderAddress = source.SenderAddress;
-            this.SenderName = source.SenderName;
-            this.SenderReplyTo = source.SenderReplyTo;
-            this.RecipientName = source.RecipientName;
-            this.CopyTo = source.CopyTo;
-            this.BlindCopyTo = source.BlindCopyTo;
-            this.Tags = source.Tags;
-            this.InlineAttachment = source.InlineAttachment;
-            this.FileAttachments = source.FileAttachments;
-            this.ProviderId = source.ProviderId;
-            this.TemplateVersionId = source.TemplateVersionId;
         }
 
         #endregion
 
         #region ISendRequest members
 
-        public string TemplateId { get; set; }
+        public virtual string TemplateId { get; set; }
 
-        public string SenderAddress { get; set; }
+        public virtual string SenderAddress { get; set; }
 
-        public string SenderName { get; set; }
+        public virtual string SenderName { get; set; }
 
-        public string SenderReplyTo { get; set; }
+        public virtual string SenderReplyTo { get; set; }
 
-        public string RecipientAddress { get; set; }
+        public virtual string RecipientAddress { get; set; }
 
-        public string RecipientName { get; set; }
+        public virtual string RecipientName { get; set; }
 
-        public IEnumerable<string> CopyTo { get; set; }
+        public virtual IEnumerable<string> CopyTo { get; set; }
 
-        public IEnumerable<string> BlindCopyTo { get; set; }
+        public virtual IEnumerable<string> BlindCopyTo { get; set; }
 
-        public IDictionary<string, string> Data { get; set; }
+        public virtual object Data { get; set; }
 
-        public IEnumerable<string> Tags { get; set; }
+        public virtual IEnumerable<string> Tags { get; set; }
 
-        public IAttachment InlineAttachment { get; set; }
+        public virtual IAttachment InlineAttachment { get; set; }
 
-        public IEnumerable<IAttachment> FileAttachments { get; set; }
+        public virtual IEnumerable<IAttachment> FileAttachments { get; set; }
 
-        public string ProviderId { get; set; }
+        public virtual string ProviderId { get; set; }
 
-        public string TemplateVersionId { get; set; }
+        public virtual string TemplateVersionId { get; set; }
 
-        public bool IsValid
+        public virtual bool IsValid
         {
             get { return this.Validate(false); }
         }
@@ -121,7 +112,7 @@ namespace SendWithUs.Client
             return this;
         }
 
-        protected bool Validate(bool throwOnFailure)
+        protected internal virtual bool Validate(bool throwOnFailure)
         {
             Func<ValidationFailureMode, bool> fail = (f) =>
             {
@@ -156,90 +147,31 @@ namespace SendWithUs.Client
         }
 
         #endregion
+    }
 
-        #region JSON conversion
+    /// <summary>
+    /// Represents the data necessary to make API requests to send email messages.
+    /// </summary>
+    /// <typeparam name="TData">The type of the Data property.</typeparam>
+    public class SendRequest<TData> : SendRequest
+    {
+        #region Constructors
 
-#if false
-        protected JObject Convert()
-        {
-            this.Validate();
+        public SendRequest() : base()
+        { }
 
-            var result = new JObject(new JProperty("email_id", this.TemplateId));
-            var recipient = new JObject(new JProperty("address", this.RecipientAddress));
+        public SendRequest(string templateId, string recipientAddress) : base(templateId, recipientAddress)
+        { }
 
-            if (!String.IsNullOrEmpty(this.RecipientName))
-            {
-                recipient.Add("name", new JValue(this.RecipientName));
-            }
-
-            result.Add("recipient", recipient);
-
-            if (this.CopyTo != null)
-            {
-                result.Add("cc", new JArray(this.CopyTo.Select(a => new JObject(new JProperty("address", a)))));
-            }
-
-            if (this.BlindCopyTo != null)
-            {
-                result.Add("bcc", new JArray(this.BlindCopyTo.Select(a => new JObject(new JProperty("address", a)))));
-            }
-
-            if (!String.IsNullOrEmpty(this.SenderAddress))
-            {
-                var sender = new JObject();
-
-                if (!String.IsNullOrEmpty(this.SenderName))
-                {
-                    sender.Add("name", this.SenderName);
-                }
-
-                if (!String.IsNullOrEmpty(this.SenderReplyTo))
-                {
-                    sender.Add("reply_to", this.SenderReplyTo);
-                }
-
-                result.Add("sender", sender);
-            }
-
-            if (this.Data != null)
-            {
-                result.Add("email_data", new JObject(this.Data.Select(kvp => new JProperty(kvp.Key, kvp.Value))));
-            }
-
-            if (this.Tags != null)
-            {
-                result.Add("tags", new JArray(this.Tags));
-            }
-
-            if (this.InlineAttachment != null)
-            {
-                result.Add("inline", this.Convert(this.InlineAttachment));
-            }
-
-            if (this.FileAttachments != null)
-            {
-                result.Add("files", new JArray(this.FileAttachments.Select(a => this.Convert(a))));
-            }
-
-            if (!String.IsNullOrEmpty(this.ProviderId))
-            {
-                result.Add("esp_account", this.ProviderId);
-            }
-
-            if (!String.IsNullOrEmpty(this.TemplateVersionId))
-            {
-                result.Add("version_name", this.TemplateVersionId);
-            }
-
-            return result;
-        }
-
-        protected JObject Convert(IAttachment attachment)
-        {
-            return new JObject(new JProperty("id", attachment.Id), new JProperty("data", attachment.Data));
-        }
-#endif
+        public SendRequest(string templateId, string recipientAddress, object data) : base(templateId, recipientAddress, data)
+        { }
 
         #endregion
+
+        public new TData Data 
+        {
+            get { return (TData)base.Data; }
+            set { base.Data = value; }
+        }
     }
 }

--- a/SendWithUs.Client/Responses/BaseResponse.cs
+++ b/SendWithUs.Client/Responses/BaseResponse.cs
@@ -26,13 +26,13 @@ namespace SendWithUs.Client
 
     public abstract class BaseResponse<T> : IResponse where T : JToken
     {
-        protected abstract void Populate(T json);
+        protected internal abstract void Populate(T json);
 
         #region IResponse members
 
-        public HttpStatusCode StatusCode { get; set; }
+        public virtual HttpStatusCode StatusCode { get; set; }
 
-        public string ErrorMessage { get; set; }
+        public virtual string ErrorMessage { get; set; }
 
         public virtual IResponse Initialize(HttpStatusCode statusCode, JToken json)
         {
@@ -52,17 +52,21 @@ namespace SendWithUs.Client
 
         #endregion
 
-        protected bool IsSuccessStatusCode()
+        #region Helpers
+
+        protected internal virtual bool IsSuccessStatusCode()
         {
             var codeValue = (int)this.StatusCode;
             return codeValue >= 200 && codeValue <= 299;
         }
 
-        protected void SetErrorMessage(JValue json)
+        protected internal virtual void SetErrorMessage(JValue json)
         {
             this.ErrorMessage = (json != null)
                 ? json.Value as String
                 : this.StatusCode.ToString();
         }
+
+        #endregion
     }
 }

--- a/SendWithUs.Client/Responses/BatchResponse.cs
+++ b/SendWithUs.Client/Responses/BatchResponse.cs
@@ -42,7 +42,7 @@ namespace SendWithUs.Client
 
         #region Base class overrides
 
-        protected override void Populate(JArray json)
+        protected internal override void Populate(JArray json)
         {
             if (json == null)
             {
@@ -51,13 +51,11 @@ namespace SendWithUs.Client
 
             this.Items = json.Zip(this.ResponseTypes, (jt, rt) => this.BuildResponse(jt as JObject, rt));
         }
-        
+
         protected IResponse BuildResponse(JObject batched, Type responseType)
         {
-            if (batched == null || responseType == null)
-            {
-                throw new ArgumentNullException();
-            }
+            EnsureArgument.NotNull(batched, "batched");
+            EnsureArgument.NotNull(responseType, "responseType");
 
             var statusCode = (HttpStatusCode)batched.Value<int>("status_code");
             var json = batched.GetValue("body") as JObject;

--- a/SendWithUs.Client/Responses/IBatchResponse.cs
+++ b/SendWithUs.Client/Responses/IBatchResponse.cs
@@ -1,4 +1,22 @@
-﻿//
+﻿// Copyright © 2014 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
 
 namespace SendWithUs.Client
 {

--- a/SendWithUs.Client/Responses/IResponseFactory.cs
+++ b/SendWithUs.Client/Responses/IResponseFactory.cs
@@ -31,6 +31,6 @@ namespace SendWithUs.Client
 
         IResponse Create(Type responseType, HttpStatusCode statusCode, JToken json);
 
-        IBatchResponse Create(HttpStatusCode statusCode, JToken json, IEnumerable<Type> responseTypes);
+        IBatchResponse Create(IEnumerable<Type> responseTypes, HttpStatusCode statusCode, JToken json);
     }
 }

--- a/SendWithUs.Client/Responses/SendResponse.cs
+++ b/SendWithUs.Client/Responses/SendResponse.cs
@@ -24,36 +24,60 @@ namespace SendWithUs.Client
 
     public class SendResponse : BaseResponse<JObject>, ISendResponse
     {
-        public bool Success { get; set; }
+        public static class PropertyNames
+        {
+            public const string Success = "success";
+            public const string Status = "status";
+            public const string ReceiptId = "receipt_id";
+            public const string Details = "email";
+            public const string TemplateName = "name";
+            public const string TemplateVersionId = "version_name";
+        }
 
-        public string Status { get; set; }
+        public virtual bool Success { get; set; }
 
-        public string ReceiptId { get; set; }
+        public virtual string Status { get; set; }
 
-        public string TemplateName { get; set; }
+        public virtual string ReceiptId { get; set; }
 
-        public string TemplateVersionId { get; set; }
+        public virtual string TemplateName { get; set; }
+
+        public virtual string TemplateVersionId { get; set; }
 
         #region Base class overrides 
 
-        protected override void Populate(JObject json)
+        protected internal override void Populate(JObject json)
         {
             if (json == null)
             {
                 return;
             }
 
-            this.Success = json.Value<bool>("success");
-            this.Status = json.Value<string>("status");
-            this.ReceiptId = json.Value<string>("receipt_id");
+            this.Success = json.Value<bool>(PropertyNames.Success);
+            this.Status = json.Value<string>(PropertyNames.Status);
+            this.ReceiptId = json.Value<string>(PropertyNames.ReceiptId);
 
-            var details = json.Property("email");
+            var details = this.GetPropertyValue(json, PropertyNames.Details);
 
-            if (details != null && details.HasValues)
+            if (details != null)
             {
-                this.TemplateName = details.Value.Value<string>("name");
-                this.TemplateVersionId = details.Value.Value<string>("version_name");
+                this.TemplateName = details.Value<string>(PropertyNames.TemplateName);
+                this.TemplateVersionId = details.Value<string>(PropertyNames.TemplateVersionId);
             }
+        }
+
+        /// <summary>
+        /// Gets the value of the named property on the specified object.
+        /// </summary>
+        /// <param name="json">The object from which to get the property value.</param>
+        /// <returns>The property value.</returns>
+        /// <remarks>This method exists to aid unit testing of Populate(), because JObject.GetValue()
+        /// is not virtual and therefore cannot be mocked.</remarks>
+        protected internal virtual JToken GetPropertyValue(JObject json, string propertyName)
+        {
+            //var details = json.Property(propertyName);
+            //return (details != null && details.HasValues) ? details.Value : null;
+            return json.GetValue(propertyName);
         }
 
         #endregion

--- a/SendWithUs.Client/SendWithUs.Client.csproj
+++ b/SendWithUs.Client/SendWithUs.Client.csproj
@@ -40,6 +40,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Helpers\Attachment.cs" />
+    <Compile Include="Helpers\EnsureArgument.cs" />
+    <Compile Include="Helpers\SerializerProxy.cs" />
     <Compile Include="Helpers\ValidationException.cs" />
     <Compile Include="Requests\BatchRequestWrapper.cs" />
     <Compile Include="Requests\BatchRequestWrapperConverter.cs" />

--- a/SendWithUs.Client/SendWithUs.Client.csproj
+++ b/SendWithUs.Client/SendWithUs.Client.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Helpers\EnsureArgument.cs" />
     <Compile Include="Helpers\SerializerProxy.cs" />
     <Compile Include="Helpers\ValidationException.cs" />
+    <Compile Include="ISendWithUsClient.cs" />
     <Compile Include="Requests\BatchRequestWrapper.cs" />
     <Compile Include="Requests\BatchRequestWrapperConverter.cs" />
     <Compile Include="Requests\ISendRequest.cs" />

--- a/SendWithUs.Client/SendWithUsClient.cs
+++ b/SendWithUs.Client/SendWithUsClient.cs
@@ -36,7 +36,7 @@ namespace SendWithUs.Client
     /// Currently, the client only covers a small portion of the API surface--namely, sending email and 
     /// batch operations. 
     /// </remarks>
-    public class SendWithUsClient
+    public class SendWithUsClient : ISendWithUsClient
     {
         #region State
 
@@ -124,7 +124,7 @@ namespace SendWithUs.Client
         /// <param name="request">A request object describing the email to be sent.</param>
         /// <returns>A response object.</returns>
         /// <exception cref="System.ArgumentNullException">The request argument was null.</exception>
-        public async Task<ISendResponse> SendAsync(ISendRequest request)
+        public virtual async Task<ISendResponse> SendAsync(ISendRequest request)
         {
             EnsureArgument.NotNull(request, "request");
 
@@ -139,7 +139,7 @@ namespace SendWithUs.Client
         /// <param name="requests">A set of request objects to be batched.</param>
         /// <returns>A response object.</returns>
         /// <exception cref="System.ArgumentNullException">The requests argument was null.</exception>
-        public async Task<IBatchResponse> BatchAsync(IEnumerable<IRequest> requests)
+        public virtual async Task<IBatchResponse> BatchAsync(IEnumerable<IRequest> requests)
         {
             EnsureArgument.NotNull(requests, "requests");
 


### PR DESCRIPTION
This PR adds a test project containing unit, component, and end-to-end tests, however the end-to-end tests are intentionally missing their data files and subsequently will all fail. In total, you should see 61 passing tests and 5 failing tests.

I've modified the type of the `SendRequest.Data` property to plain old `object`. The onus is on the caller to supply a value that will serialize as a JSON object (because that is what the SendWithUs REST API expects). I also added a derived class `SendRequest<T>` which simply shadows the `Data` property and casts it to type `T`.

Most of the changes suggested in the [previous code review](https://github.com/Mimeo/SendWithUs.Client/pull/2) have also been folded in to this PR.