### PR TITLE
Catch error responses from the server

### DIFF
--- a/SendWithUs.Client.Tests/EndToEnd/SendAsyncTests.cs
+++ b/SendWithUs.Client.Tests/EndToEnd/SendAsyncTests.cs
@@ -117,5 +117,37 @@ namespace SendWithUs.Client.Tests.EndToEnd
             Assert.AreEqual("OK", response.Status, true);
             Assert.AreEqual(true, response.Success);
         }
+
+		class BigDataClass
+		{
+			public BigDataClass()
+			{
+				var data = new List<string>();
+				for (int i = 0; i < 100000; ++i)
+					data.Add(Guid.NewGuid().ToString());
+				this.Data = data;
+			}
+			public IEnumerable<string> Data { get; set; }
+		}
+
+		[TestMethod]
+		public void SendAsync_WithTooMuchData_Throws()
+		{
+			// Arrange
+			var testData = new TestData("EndToEnd/Data/SendRequest.xml");
+			var request = new SendRequest(testData.TemplateId, testData.RecipientAddress)
+				{
+					Data = new BigDataClass()
+				};
+			var client = new SendWithUsClient(testData.ApiKey);
+
+			request.SenderAddress = testData.SenderAddress;
+			
+			// Act
+			var exception = TestHelper.CaptureException(() => client.SendAsync(request));
+
+			// Assert
+			Assert.IsInstanceOfType(exception, typeof(ErrorResponseException));
+		}
     }
 }

--- a/SendWithUs.Client/Helpers/ErrorResponseException.cs
+++ b/SendWithUs.Client/Helpers/ErrorResponseException.cs
@@ -1,0 +1,32 @@
+﻿// Copyright © 2014 Mimeo, Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+namespace SendWithUs.Client
+{
+    using System;
+
+    public class ErrorResponseException : Exception
+    {
+		public ErrorResponseException(string responseMessage)
+			: base(responseMessage)
+        {
+        }
+    }
+}

--- a/SendWithUs.Client/SendWithUs.Client.csproj
+++ b/SendWithUs.Client/SendWithUs.Client.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Helpers\Attachment.cs" />
     <Compile Include="Helpers\EnsureArgument.cs" />
     <Compile Include="Helpers\SerializerProxy.cs" />
+    <Compile Include="Helpers\ErrorResponseException.cs" />
     <Compile Include="Helpers\ValidationException.cs" />
     <Compile Include="ISendWithUsClient.cs" />
     <Compile Include="Requests\BaseConverter.cs" />

--- a/SendWithUs.Client/SendWithUsClient.cs
+++ b/SendWithUs.Client/SendWithUsClient.cs
@@ -202,6 +202,18 @@ namespace SendWithUs.Client
             where TResponse : class, IResponse
         { 
             var httpResponse = await this.GetHttpResponseAsync(request);
+			if (!httpResponse.IsSuccessStatusCode)
+			{
+				string contentType = httpResponse.Content.Headers.ContentType.MediaType;
+				if (contentType == "text/html")
+				{
+					string content = await httpResponse.Content.ReadAsStringAsync();
+					throw new ErrorResponseException(content);
+				}
+
+				// Fall through. The EnsureSuccessStatusCode will catch it.
+			}
+
             var json = await httpResponse.EnsureSuccessStatusCode().Content.ReadAsAsync<JToken>();
             return this.ResponseFactory.Create<TResponse>(httpResponse.StatusCode, json);
         }


### PR DESCRIPTION
Sometimes, SendWithUs will respond to a Send request with a `content-type` of `text/html` containing a text message. Sending too much data will trigger such a response.

This change should catch that response and throw an exception including the error response message. 

Much better that asserting a 200 response and discarding any knowledge of the error.
